### PR TITLE
docs: add project planning documents

### DIFF
--- a/DEV_PLAN.md
+++ b/DEV_PLAN.md
@@ -1,0 +1,24 @@
+# Development Plan
+
+This document outlines the initial milestones for building the AI-customizable text editor.
+
+## Milestones
+1. **Research & Architecture**
+   - Finalize technology choice (Tiptap or Lexical).
+   - Define sandbox model for executing AI-generated code safely.
+2. **Minimal Prototype**
+   - Render an empty editor with slash-command palette.
+   - Allow LLM to propose extensions and register them in a sandbox.
+3. **Extension Sandbox**
+   - Implement isolation using QuickJS or WebContainers.
+   - Restrict capabilities and expose a minimal API surface.
+4. **UI Manifest System**
+   - Translate LLM output into declarative UI descriptions.
+   - Host application renders panels/buttons based on manifests.
+5. **Testing & Hardening**
+   - Add unit tests for sandbox and extension loader.
+   - Document security policies and review process.
+
+## Open Questions
+- How to persist user-approved extensions across sessions?
+- What review flow is required for network or file-system access?

--- a/FILE_STRUCTURE.md
+++ b/FILE_STRUCTURE.md
@@ -1,0 +1,17 @@
+# File Structure Plan
+
+The repository is currently documentation-only. The following structure describes the layout once development begins.
+
+```
+textio/
+├── src/              # Application source code
+│   ├── editor/       # Core editor components
+│   ├── extensions/   # AI-generated and built-in extensions
+│   └── ui/           # Rendering logic for manifests
+├── tests/            # Unit and integration tests
+├── scripts/          # Utility scripts (build, lint, etc.)
+├── docs/             # Additional project documentation
+└── package.json      # Project metadata and npm scripts
+```
+
+This structure is expected to evolve as features are implemented.

--- a/README.md
+++ b/README.md
@@ -26,3 +26,9 @@ npm test
 
 ## AGENTS.md Summary
 AGENTS.md surveys existing customizable editors like Emacs with gptel, VS Code with Continue, Obsidian, and headless frameworks such as Tiptap and Lexical. The research concludes that no mainstream editor yet lets AI reconfigure the UI on the fly, but these tools show a practical path. It also sketches how an LLM could generate and safely load extensions in a sandboxed environment.
+
+## Documentation
+- [Development Plan](DEV_PLAN.md)
+- [File Structure Plan](FILE_STRUCTURE.md)
+- [UI/UX Plan](UI_UX_PLAN.md)
+- [Sources Information](Sourses_info.md)

--- a/Sourses_info.md
+++ b/Sourses_info.md
@@ -1,0 +1,12 @@
+# Sources Information
+
+Key references that informed the project:
+
+- [Emacs gptel](https://github.com/karthink/gptel) – LLM integration for Emacs.
+- [Continue.dev](https://docs.continue.dev/getting-started/overview) – AI-assisted workflows in VS Code.
+- [Zed AI announcement](https://zed.dev/blog/zed-ai) – Example of extensible editor with AI features.
+- [Obsidian plugins](https://obsidian.md/plugins) – Rich plugin ecosystem for a minimal editor.
+- [Tiptap](https://tiptap.dev/docs/editor/getting-started/overview) – Headless editor framework suited for dynamic extensions.
+- [Lexical](https://github.com/facebook/lexical) – Modular text editor engine from Meta.
+
+These sources are summarized and discussed in AGENTS.md.

--- a/UI_UX_PLAN.md
+++ b/UI_UX_PLAN.md
@@ -1,0 +1,19 @@
+# UI/UX Plan
+
+The editor starts with an almost blank canvas and grows with user intent.
+
+## Core Concepts
+- **Minimal Start**: initial interface shows only a text area and a command palette.
+- **Slash Commands**: users type `/` to request features or actions.
+- **AI-Suggested Panels**: LLM proposes UI panels (e.g., formatting toolbar, outline view) which the user can accept or dismiss.
+- **Customizable Layout**: accepted panels can be rearranged, hidden, or removed through commands.
+
+## User Flow
+1. User types `/bold` → LLM loads a formatting panel.
+2. User removes panel via `/hide formatting`.
+3. LLM stores layout preferences for future sessions.
+
+## Accessibility & Feedback
+- Keyboard-first interactions with accessible labels.
+- Lightweight notifications explain new panels or commands.
+- Undo/rollback available for AI-added features.


### PR DESCRIPTION
## Summary
- add initial development plan with milestones and open questions
- document prospective file layout for the project
- outline UI/UX approach and list key reference sources
- link planning documents from the README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f98e14ac83279932fa95cd42137e