### PR TITLE
docs: expand development roadmap

### DIFF
--- a/DEV_PLAN.md
+++ b/DEV_PLAN.md
@@ -1,24 +1,30 @@
 # Development Plan
 
-This document outlines the initial milestones for building the AI-customizable text editor.
+This document outlines milestones for building the AI‑customizable text editor and tracks current progress.
 
 ## Milestones
-1. **Research & Architecture**
-   - Finalize technology choice (Tiptap or Lexical).
-   - Define sandbox model for executing AI-generated code safely.
+1. **Research & Architecture** *(in progress)*
+   - Select headless editor framework (**Tiptap** chosen for MVP due to extension-friendly API).
+   - Define sandbox model for executing AI-generated code safely (evaluate QuickJS vs WebContainers).
+   - Draft minimal API contract that extensions can access.
 2. **Minimal Prototype**
-   - Render an empty editor with slash-command palette.
-   - Allow LLM to propose extensions and register them in a sandbox.
+   - Render a minimal Tiptap instance with slash-command palette.
+   - Wire an LLM endpoint that proposes extensions.
+   - Allow LLM to register a simple command extension in a sandbox.
 3. **Extension Sandbox**
    - Implement isolation using QuickJS or WebContainers.
    - Restrict capabilities and expose a minimal API surface.
+   - Provide a review/approval step before mounting new extensions.
 4. **UI Manifest System**
    - Translate LLM output into declarative UI descriptions.
    - Host application renders panels/buttons based on manifests.
+   - Persist accepted manifests to local storage for future sessions.
 5. **Testing & Hardening**
    - Add unit tests for sandbox and extension loader.
    - Document security policies and review process.
+   - Conduct manual security and UX reviews.
 
 ## Open Questions
 - How to persist user-approved extensions across sessions?
 - What review flow is required for network or file-system access?
+- How to version generated extensions and allow rollback?

--- a/FILE_STRUCTURE.md
+++ b/FILE_STRUCTURE.md
@@ -4,14 +4,18 @@ The repository is currently documentation-only. The following structure describe
 
 ```
 textio/
-├── src/              # Application source code
-│   ├── editor/       # Core editor components
-│   ├── extensions/   # AI-generated and built-in extensions
-│   └── ui/           # Rendering logic for manifests
-├── tests/            # Unit and integration tests
-├── scripts/          # Utility scripts (build, lint, etc.)
-├── docs/             # Additional project documentation
-└── package.json      # Project metadata and npm scripts
+├── src/                  # Application source code
+│   ├── editor/           # Core editor components
+│   ├── extensions/       # AI-generated and built-in extensions
+│   ├── sandbox/          # Isolation layer for executing generated code
+│   ├── manifest/         # Types and helpers for declarative UI manifests
+│   └── ui/               # Rendering logic for manifests
+├── tests/                # Unit and integration tests
+│   ├── sandbox/          # Tests for sandbox and extension loader
+│   └── editor/           # Tests for editor behaviours
+├── scripts/              # Utility scripts (build, lint, etc.)
+├── docs/                 # Additional project documentation
+└── package.json          # Project metadata and npm scripts
 ```
 
 This structure is expected to evolve as features are implemented.

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ An AI-driven, highly customizable text editor that starts from a minimal interfa
 Our goal is to create a "blank" editor where an LLM can add or remove panels, commands, and behaviors on demand, so every user can shape the environment to their workflow.
 
 ## Status
-The project is in an early research phase. There is no runnable code yet, but AGENTS.md captures exploration of existing tools and architectural ideas.
+The project is in an early research phase. Documentation captures architectural exploration, and the MVP will likely be built on **Tiptap**. There is no runnable code yet.
 
 ## Roadmap
-- Build a minimal prototype (e.g., Tiptap or Lexical based) demonstrating dynamic AI-generated extensions.
-- Add a secure sandbox for executing model-written plugins.
-- Provide declarative UI manifests so AI proposals translate into safe interface changes.
-- Document plugin APIs and contributor guidelines.
+- Build a minimal Tiptap-based prototype demonstrating dynamic AI-generated extensions via slash commands.
+- Add a secure sandbox (QuickJS or WebContainers) for executing model-written plugins with a restricted API.
+- Provide declarative UI manifests so AI proposals translate into safe interface changes and persist accepted panels.
+- Document plugin APIs, contributor guidelines, and security review process.
 
 ## Quick Start
 ```bash

--- a/Sourses_info.md
+++ b/Sourses_info.md
@@ -8,5 +8,8 @@ Key references that informed the project:
 - [Obsidian plugins](https://obsidian.md/plugins) – Rich plugin ecosystem for a minimal editor.
 - [Tiptap](https://tiptap.dev/docs/editor/getting-started/overview) – Headless editor framework suited for dynamic extensions.
 - [Lexical](https://github.com/facebook/lexical) – Modular text editor engine from Meta.
+- [QuickJS](https://github.com/bellard/quickjs) – Embeddable JS engine for sandboxing model-generated code.
+- [WebContainers](https://blog.stackblitz.com/posts/introducing-webcontainers/) – Run Node.js in the browser for isolated build environments.
+- [SES](https://github.com/endojs/endo) – Secure ECMAScript compartments for capability-based isolation.
 
 These sources are summarized and discussed in AGENTS.md.

--- a/UI_UX_PLAN.md
+++ b/UI_UX_PLAN.md
@@ -6,14 +6,17 @@ The editor starts with an almost blank canvas and grows with user intent.
 - **Minimal Start**: initial interface shows only a text area and a command palette.
 - **Slash Commands**: users type `/` to request features or actions.
 - **AI-Suggested Panels**: LLM proposes UI panels (e.g., formatting toolbar, outline view) which the user can accept or dismiss.
+- **Extension Approval**: proposed panels/extensions appear with a preview and require user confirmation before mounting.
 - **Customizable Layout**: accepted panels can be rearranged, hidden, or removed through commands.
 
 ## User Flow
-1. User types `/bold` → LLM loads a formatting panel.
-2. User removes panel via `/hide formatting`.
-3. LLM stores layout preferences for future sessions.
+1. User types `/bold` → LLM proposes a formatting panel with a preview.
+2. User accepts the proposal; the panel is mounted and registered in the sandbox.
+3. User removes panel via `/hide formatting` or declines the proposal.
+4. Layout preferences and accepted manifests are stored for future sessions.
 
 ## Accessibility & Feedback
 - Keyboard-first interactions with accessible labels.
-- Lightweight notifications explain new panels or commands.
+- Lightweight notifications explain new panels or commands and show when sandboxed code is executing.
 - Undo/rollback available for AI-added features.
+- Confirmation dialogs for actions that request elevated capabilities.


### PR DESCRIPTION
## Summary
- detail milestones and choose Tiptap for MVP in development plan
- expand planned file structure with sandbox and manifest directories
- refine roadmap, UI/UX plan, and sources reference

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fc0cd1b88327a6745f19b97fe419